### PR TITLE
Add backwards compatible code for `storms` update

### DIFF
--- a/vignettes/simplevis.Rmd
+++ b/vignettes/simplevis.Rmd
@@ -410,6 +410,8 @@ Below illustrates how to customise titles and control labels through all possibl
 
 ```{r}
 plot_data <- storms %>%
+  filter(status %in% c("hurricane", "tropical depression", "tropical storm")) %>%
+  mutate(status = forcats::fct_drop(status)) %>%
   group_by(year, status) %>%
   summarise(wind = mean(wind))
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The `storms` dataset has been updated with more recent data. In particular, one thing that broke your vignette was that there previously were 3 `status` values and now there are 9. I've added some backwards compatible code to make it work again, but it also might be worth rethinking this example too (possibly you could avoid hardcoding the 3 shorter column labels or something).

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!